### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ describe('some thing', () => {
     button.click();
 
     waitUntil(() => paragraph.text())
-      .then((text) => expect(test).toBe('The text in the paragraph'));
+      .then((text) => expect(text).toBe('The text in the paragraph'))
+      .then(() => done());
   })
 })
 ```


### PR DESCRIPTION
Came across this package in the search of a way to remove some hard coded waits in [WebAssembly Studios](https://github.com/wasdk/WebAssemblyStudio) test suite 👍

Not sure if this is actively maintained but went ahead anyways and fixed a small typo in the example provided in the README.